### PR TITLE
Update Actions for Apple Platforms

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,24 +86,24 @@ jobs:
 
       # Build for iOS
       - name: Build iOS
-        run: xcodebuild -scheme FowlerNollVo-Package -destination "platform=iOS Simulator,name=iPhone 12,OS=14.5"
+        run: xcodebuild -scheme FowlerNollVo-Package -destination "platform=iOS Simulator,name=iPhone 12,OS=15.0"
 
       # Test on iOS
       - name: Test iOS
-        run: xcodebuild test -scheme FowlerNollVo-Package -destination "platform=iOS Simulator,name=iPhone 12,OS=14.5"
+        run: xcodebuild test -scheme FowlerNollVo-Package -destination "platform=iOS Simulator,name=iPhone 12,OS=15.0"
 
       # Build for watchOS
       - name: Build watchOS
-        run: xcodebuild -scheme FowlerNollVo-Package -destination "platform=watchOS Simulator,name=Apple Watch Series 6 - 44mm,OS=7.4"
+        run: xcodebuild -scheme FowlerNollVo-Package -destination "platform=watchOS Simulator,name=Apple Watch Series 6 - 44mm,OS=8.0"
 
       # Test on watchOS
       - name: Test watchOS
-        run: xcodebuild test -scheme FowlerNollVo-Package -destination "platform=watchOS Simulator,name=Apple Watch Series 6 - 44mm,OS=7.4"
+        run: xcodebuild test -scheme FowlerNollVo-Package -destination "platform=watchOS Simulator,name=Apple Watch Series 6 - 44mm,OS=8.0"
 
       # Build for tvOS
       - name: Build tvOS
-        run: xcodebuild -scheme FowlerNollVo-Package -destination "platform=tvOS Simulator,name=Apple TV 4K,OS=14.5"
+        run: xcodebuild -scheme FowlerNollVo-Package -destination "platform=tvOS Simulator,name=Apple TV 4K,OS=15.0"
 
       # Test on tvOS
       - name: Test tvOS
-        run: xcodebuild test -scheme FowlerNollVo-Package -destination "platform=tvOS Simulator,name=Apple TV 4K,OS=14.5"
+        run: xcodebuild test -scheme FowlerNollVo-Package -destination "platform=tvOS Simulator,name=Apple TV 4K,OS=15.0"


### PR DESCRIPTION
This pull request bumps the simulator OS version for all apple platform test devices to 2021 releases. This includes iOS 15.0, watchOS 8.0, tvOS 15.0.