### PR TITLE
Add Type Aliases for `DoubleWidth` Digests

### DIFF
--- a/Sources/FowlerNollVo/Hashers/FNV1024.swift
+++ b/Sources/FowlerNollVo/Hashers/FNV1024.swift
@@ -5,52 +5,59 @@
 //  Created by Christopher Richez on 2/2/22.
 //
 
-extension DoubleWidth where Base == DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>> {
-    fileprivate static var fnvPrime: DoubleWidth<DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>> {
-        DoubleWidth<DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>>(
-            DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>(
-                DoubleWidth<DoubleWidth<UInt64>>(
-                    DoubleWidth<UInt64>(0x0000000000000000, 0x0000000000000000),
-                    DoubleWidth<UInt64>(0x0000000000000000, 0x0000000000000000)
+/// A 1024-bit digest that behaves like an unsigned integer.
+///
+/// `DoubleWidth` is from the [Swift numerics](https://github.com/apple/swift-numerics)
+/// open-source project. Expect all operations on a `Digest1024` value to perform
+/// significantly worse than operations on `UInt64` and other standard library native integers.
+public typealias Digest1024 = DoubleWidth<Digest512>
+
+extension Digest1024 {
+    fileprivate static var fnvPrime: Digest1024 {
+        Digest1024(
+            Digest512(
+                Digest256(
+                    Digest128(0x0000000000000000, 0x0000000000000000),
+                    Digest128(0x0000000000000000, 0x0000000000000000)
                 ),
-                DoubleWidth<DoubleWidth<UInt64>>(
-                    DoubleWidth<UInt64>(0x0000000000000000, 0x0000010000000000),
-                    DoubleWidth<UInt64>(0x0000000000000000, 0x0000000000000000)
+                Digest256(
+                    Digest128(0x0000000000000000, 0x0000010000000000),
+                    Digest128(0x0000000000000000, 0x0000000000000000)
                 )
             ),
-            DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>(
-                DoubleWidth<DoubleWidth<UInt64>>(
-                    DoubleWidth<UInt64>(0x0000000000000000, 0x0000000000000000),
-                    DoubleWidth<UInt64>(0x0000000000000000, 0x0000000000000000)
+            Digest512(
+                Digest256(
+                    Digest128(0x0000000000000000, 0x0000000000000000),
+                    Digest128(0x0000000000000000, 0x0000000000000000)
                 ),
-                DoubleWidth<DoubleWidth<UInt64>>(
-                    DoubleWidth<UInt64>(0x0000000000000000, 0x0000000000000000),
-                    DoubleWidth<UInt64>(0x0000000000000000, 0x000000000000018D)
+                Digest256(
+                    Digest128(0x0000000000000000, 0x0000000000000000),
+                    Digest128(0x0000000000000000, 0x000000000000018D)
                 )
             )
         )
     }
     
-    fileprivate static var fnvOffset: DoubleWidth<DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>> {
-        DoubleWidth<DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>>(
-            DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>(
-                DoubleWidth<DoubleWidth<UInt64>>(
-                    DoubleWidth<UInt64>(0x0000000000000000, 0x005f7a76758ecc4d),
-                    DoubleWidth<UInt64>(0x32e56d5a591028b7, 0x4b29fc4223fdada1)
+    fileprivate static var fnvOffset: Digest1024 {
+        Digest1024(
+            Digest512(
+                Digest256(
+                    Digest128(0x0000000000000000, 0x005f7a76758ecc4d),
+                    Digest128(0x32e56d5a591028b7, 0x4b29fc4223fdada1)
                 ),
-                DoubleWidth<DoubleWidth<UInt64>>(
-                    DoubleWidth<UInt64>(0x6c3bf34eda3674da, 0x9a21d90000000000),
-                    DoubleWidth<UInt64>(0x0000000000000000, 0x0000000000000000)
+                Digest256(
+                    Digest128(0x6c3bf34eda3674da, 0x9a21d90000000000),
+                    Digest128(0x0000000000000000, 0x0000000000000000)
                 )
             ),
-            DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>(
-                DoubleWidth<DoubleWidth<UInt64>>(
-                    DoubleWidth<UInt64>(0x0000000000000000, 0x0000000000000000),
-                    DoubleWidth<UInt64>(0x0000000000000000, 0x000000000004c6d7)
+            Digest512(
+                Digest256(
+                    Digest128(0x0000000000000000, 0x0000000000000000),
+                    Digest128(0x0000000000000000, 0x000000000004c6d7)
                 ),
-                DoubleWidth<DoubleWidth<UInt64>>(
-                    DoubleWidth<UInt64>(0xeb6e73802734510a, 0x555f256cc005ae55),
-                    DoubleWidth<UInt64>(0x6bde8cc9c6a93b21, 0xaff4b16c71ee90b3)
+                Digest256(
+                    Digest128(0xeb6e73802734510a, 0x555f256cc005ae55),
+                    Digest128(0x6bde8cc9c6a93b21, 0xaff4b16c71ee90b3)
                 )
             )
         )
@@ -58,9 +65,9 @@ extension DoubleWidth where Base == DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>
 }
 
 
-/// A `FNV-1` hasher with a `DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>` digest.
+/// A `FNV-1` hasher with a `Digest1024` digest.
 public struct FNV1024: FNVHasher {
-    public private(set) var digest: DoubleWidth<DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>>
+    public private(set) var digest: Digest1024
     
     public init() {
         self.digest = .fnvOffset
@@ -88,9 +95,9 @@ public struct FNV1024: FNVHasher {
     }
 }
 
-/// A `FNV-1a` hasher with a `DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>` digest.
+/// A `FNV-1a` hasher with a `Digest1024` digest.
 public struct FNV1024a: FNVHasher {
-    public private(set) var digest: DoubleWidth<DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>>
+    public private(set) var digest: Digest1024
     
     public init() {
         self.digest = .fnvOffset

--- a/Sources/FowlerNollVo/Hashers/FNV128.swift
+++ b/Sources/FowlerNollVo/Hashers/FNV128.swift
@@ -5,19 +5,26 @@
 //  Created by Christopher Richez on 2/2/22.
 //
 
-extension DoubleWidth where Base == UInt64 {
-    fileprivate static var fnvPrime: DoubleWidth<UInt64> {
-        DoubleWidth<UInt64>(0x0000000001000000, 0x000000000000013B)
+/// A 128-bit digest that behaves like an unsigned integer.
+///
+/// `DoubleWidth` is from the [Swift numerics](https://github.com/apple/swift-numerics)
+/// open-source project. Expect all operations on a `Digest128` value to perform slighly worse
+/// than operations on `UInt64` and other standard library native integers.
+public typealias Digest128 = DoubleWidth<UInt64>
+
+extension Digest128 {
+    fileprivate static var fnvPrime: Digest128 {
+        Digest128(0x0000000001000000, 0x000000000000013B)
     }
     
-    fileprivate static var fnvOffset: DoubleWidth<UInt64> {
-        DoubleWidth<UInt64>(0x6c62272e07bb0142, 0x62b821756295c58d)
+    fileprivate static var fnvOffset: Digest128 {
+        Digest128(0x6c62272e07bb0142, 0x62b821756295c58d)
     }
 }
 
-/// A `FNV-1` hasher with a `DoubleWidth<UInt64>` digest.
+/// A `FNV-1` hasher with a `Digest128` digest.
 public struct FNV128: FNVHasher {
-    public private(set) var digest: DoubleWidth<UInt64>
+    public private(set) var digest: Digest128
     
     public init() {
         self.digest = .fnvOffset
@@ -45,9 +52,9 @@ public struct FNV128: FNVHasher {
     }
 }
 
-/// A `FNV-1a` hasher with a `DoubleWidth<UInt64>` digest.
+/// A `FNV-1a` hasher with a `Digest128` digest.
 public struct FNV128a: FNVHasher {
-    public private(set) var digest: DoubleWidth<UInt64>
+    public private(set) var digest: Digest128
     
     public init() {
         self.digest = .fnvOffset

--- a/Sources/FowlerNollVo/Hashers/FNV256.swift
+++ b/Sources/FowlerNollVo/Hashers/FNV256.swift
@@ -5,24 +5,32 @@
 //  Created by Christopher Richez on 2/2/22.
 //
 
-extension DoubleWidth where Base == DoubleWidth<UInt64> {
-    fileprivate static var fnvPrime: DoubleWidth<DoubleWidth<UInt64>> {
-        DoubleWidth<DoubleWidth<UInt64>>(
-            DoubleWidth<UInt64>(0x0000000000000000, 0x0000010000000000),
-            DoubleWidth<UInt64>(0x0000000000000000, 0x0000000000000163)
+/// A 256-bit digest that behaves like an unsigned integer.
+///
+/// `DoubleWidth` is from the [Swift numerics](https://github.com/apple/swift-numerics)
+/// open-source project. Expect all operations on a `Digest256` value to perform slighly worse
+/// than operations on `UInt64` and other standard library native integers.
+public typealias Digest256 = DoubleWidth<Digest128>
+
+extension Digest256 {
+    fileprivate static var fnvPrime: Digest256 {
+        Digest256(
+            Digest128(0x0000000000000000, 0x0000010000000000),
+            Digest128(0x0000000000000000, 0x0000000000000163)
         )
     }
-    fileprivate static var fnvOffset: DoubleWidth<DoubleWidth<UInt64>> {
-        DoubleWidth<DoubleWidth<UInt64>>(
-            DoubleWidth<UInt64>(0xdd268dbcaac55036, 0x2d98c384c4e576cc),
-            DoubleWidth<UInt64>(0xc8b1536847b6bbb3, 0x1023b4c8caee0535)
+    
+    fileprivate static var fnvOffset: Digest256 {
+        Digest256(
+            Digest128(0xdd268dbcaac55036, 0x2d98c384c4e576cc),
+            Digest128(0xc8b1536847b6bbb3, 0x1023b4c8caee0535)
         )
     }
 }
 
-/// A `FNV-1` hasher with a `DoubleWidth<DoubleWidth<UInt64>>` digest.
+/// A `FNV-1` hasher with a `Digest256` digest.
 public struct FNV256: FNVHasher {
-    public private(set) var digest: DoubleWidth<DoubleWidth<UInt64>>
+    public private(set) var digest: Digest256
     
     public init() {
         self.digest = .fnvOffset
@@ -50,9 +58,9 @@ public struct FNV256: FNVHasher {
     }
 }
 
-/// A `FNV-1a` hasher with a `DoubleWidth<DoubleWidth<UInt64>>` digest.
+/// A `FNV-1a` hasher with a `Digest256` digest.
 public struct FNV256a: FNVHasher {
-    public private(set) var digest: DoubleWidth<DoubleWidth<UInt64>>
+    public private(set) var digest: Digest256
     
     public init() {
         self.digest = .fnvOffset

--- a/Sources/FowlerNollVo/Hashers/FNV512.swift
+++ b/Sources/FowlerNollVo/Hashers/FNV512.swift
@@ -5,7 +5,7 @@
 //  Created by Christopher Richez on 2/2/22.
 //
 
-/// A 128-bit digest that behaves like an unsigned integer.
+/// A 512-bit digest that behaves like an unsigned integer.
 ///
 /// `DoubleWidth` is from the [Swift numerics](https://github.com/apple/swift-numerics)
 /// open-source project. Expect all operations on a `Digest512` value to perform

--- a/Sources/FowlerNollVo/Hashers/FNV512.swift
+++ b/Sources/FowlerNollVo/Hashers/FNV512.swift
@@ -5,38 +5,45 @@
 //  Created by Christopher Richez on 2/2/22.
 //
 
-extension DoubleWidth where Base == DoubleWidth<DoubleWidth<UInt64>> {
-    fileprivate static var fnvPrime: DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>> {
-        DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>(
-            DoubleWidth<DoubleWidth<UInt64>>(
-                DoubleWidth<UInt64>(0x0000000000000000, 0x0000000000000000),
-                DoubleWidth<UInt64>(0x0000000001000000, 0x0000000000000000)
+/// A 128-bit digest that behaves like an unsigned integer.
+///
+/// `DoubleWidth` is from the [Swift numerics](https://github.com/apple/swift-numerics)
+/// open-source project. Expect all operations on a `Digest512` value to perform
+/// noticeably worse than operations on `UInt64` and other standard library native integers.
+public typealias Digest512 = DoubleWidth<Digest256>
+
+extension Digest512 {
+    fileprivate static var fnvPrime: Digest512 {
+        Digest512(
+            Digest256(
+                Digest128(0x0000000000000000, 0x0000000000000000),
+                Digest128(0x0000000001000000, 0x0000000000000000)
             ),
-            DoubleWidth<DoubleWidth<UInt64>>(
-                DoubleWidth<UInt64>(0x0000000000000000, 0x0000000000000000),
-                DoubleWidth<UInt64>(0x0000000000000000, 0x0000000000000157)
+            Digest256(
+                Digest128(0x0000000000000000, 0x0000000000000000),
+                Digest128(0x0000000000000000, 0x0000000000000157)
             )
         )
     }
     
-    fileprivate static var fnvOffset: DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>> {
-        DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>(
-            DoubleWidth<DoubleWidth<UInt64>>(
-                DoubleWidth<UInt64>(0xb86db0b1171f4416, 0xdca1e50f309990ac),
-                DoubleWidth<UInt64>(0xac87d059c9000000, 0x0000000000000d21)
+    fileprivate static var fnvOffset: Digest512 {
+        Digest512(
+            Digest256(
+                Digest128(0xb86db0b1171f4416, 0xdca1e50f309990ac),
+                Digest128(0xac87d059c9000000, 0x0000000000000d21)
             ),
-            DoubleWidth<DoubleWidth<UInt64>>(
-                DoubleWidth<UInt64>(0xe948f68a34c192f6, 0x2ea79bc942dbe7ce),
-                DoubleWidth<UInt64>(0x182036415f56e34b, 0xac982aac4afe9fd9)
+            Digest256(
+                Digest128(0xe948f68a34c192f6, 0x2ea79bc942dbe7ce),
+                Digest128(0x182036415f56e34b, 0xac982aac4afe9fd9)
             )
         )
     }
 }
 
 
-/// A `FNV-1` hasher with a `DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>` digest.
+/// A `FNV-1` hasher with a `Digest512` digest.
 public struct FNV512: FNVHasher {
-    public private(set) var digest: DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>
+    public private(set) var digest: Digest512
     
     public init() {
         self.digest = .fnvOffset
@@ -64,9 +71,9 @@ public struct FNV512: FNVHasher {
     }
 }
 
-/// A `FNV-1a` hasher with a `DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>` digest.
+/// A `FNV-1a` hasher with a `Digest512` digest.
 public struct FNV512a: FNVHasher {
-    public private(set) var digest: DoubleWidth<DoubleWidth<DoubleWidth<UInt64>>>
+    public private(set) var digest: Digest512
     
     public init() {
         self.digest = .fnvOffset


### PR DESCRIPTION
### Objectives

This pull request hopes to clarify and clean up code that uses nested `DoubleWidth` types, and close #27. The following type aliases were added:
* `Digest128`
* `Digest256`
* `Digest512`
* `Digest1024`

### Tasks

- [x] Replace references to `DoubleWidth`
- [x] Update documentation to warn clients about performance drawbacks of large digests
- [x] Ensure all existing tests still pass