### PR TITLE
Fix `Float16` Extension Availability

### DIFF
--- a/Sources/FowlerNollVo/FNVHashable.swift
+++ b/Sources/FowlerNollVo/FNVHashable.swift
@@ -58,14 +58,8 @@ extension Float: FNVHashable {
     }
 }
 
-#if arch(arm)
-@available(macOS 11, *)
-@available(macCatalyst 14, *)
-@available(macOSApplicationExtension 11, *)
-@available(macCatalystApplicationExtension 14, *)
-@available(iOS 14, *)
-@available(watchOS 7, *)
-@available(tvOS 14, *)
+#if swift(>=5.4) && !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
+@available(macOS 11, iOS 14, watchOS 7, tvOS 14, *)
 extension Float16: FNVHashable {
     public func hash<Hasher>(into hasher: inout Hasher) where Hasher : FNVHasher {
         withUnsafeBytes(of: self) { hasher.combine($0) }

--- a/Tests/FowlerNollVoTests/HashStabilityTests.swift
+++ b/Tests/FowlerNollVoTests/HashStabilityTests.swift
@@ -43,6 +43,26 @@ class HashStabilityTests: XCTestCase {
         }
     }
     
+    #if swift(>=5.4) && !(os(macOS) || targetEnvironment(macCatalyst) && arch(x86_64))
+    /// An array of randomly generated `FNVHashable` values.
+    let inputs: [FNVHashable] = [
+        "this is a test \u{10424}", String?.none,
+        Bool.random(), Bool?.none,
+        Int.random(in: .min ... .max), Int?.none,
+        Int8.random(in: .min ... .max), Int8?.none,
+        Int16.random(in: .min ... .max), Int16?.none,
+        Int32.random(in: .min ... .max), Int32?.none,
+        Int64.random(in: .min ... .max), Int64?.none,
+        UInt.random(in: .min ... .max), UInt?.none,
+        UInt8.random(in: .min ... .max), UInt8?.none,
+        UInt16.random(in: .min ... .max), UInt16?.none,
+        UInt32.random(in: .min ... .max), UInt32?.none,
+        UInt64.random(in: .min ... .max), UInt64?.none,
+        Double.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude), Double?.none,
+        Float.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude), Float?.none,
+        Float16.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude), Float16?.none
+    ]
+    #else
     /// An array of randomly generated `FNVHashable` values.
     let inputs: [FNVHashable] = [
         "this is a test \u{10424}", String?.none,
@@ -60,6 +80,8 @@ class HashStabilityTests: XCTestCase {
         Double.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude), Double?.none,
         Float.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude), Float?.none,
     ]
+    #endif
+    
     
     /// Calls `checkStability(of:withHasher:)` for each input in `inputs` and every hasher type.
     ///

--- a/Tests/FowlerNollVoTests/HashStabilityTests.swift
+++ b/Tests/FowlerNollVoTests/HashStabilityTests.swift
@@ -43,7 +43,7 @@ class HashStabilityTests: XCTestCase {
         }
     }
     
-    #if swift(>=5.4) && !(os(macOS) || targetEnvironment(macCatalyst) && arch(x86_64))
+    #if swift(>=5.4) && !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
     /// An array of randomly generated `FNVHashable` values.
     let inputs: [FNVHashable] = [
         "this is a test \u{10424}", String?.none,

--- a/Tests/FowlerNollVoTests/HashStabilityTests.swift
+++ b/Tests/FowlerNollVoTests/HashStabilityTests.swift
@@ -43,27 +43,6 @@ class HashStabilityTests: XCTestCase {
         }
     }
     
-    #if swift(>=5.4) && !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-    /// An array of randomly generated `FNVHashable` values.
-    let inputs: [FNVHashable] = [
-        "this is a test \u{10424}", String?.none,
-        Bool.random(), Bool?.none,
-        Int.random(in: .min ... .max), Int?.none,
-        Int8.random(in: .min ... .max), Int8?.none,
-        Int16.random(in: .min ... .max), Int16?.none,
-        Int32.random(in: .min ... .max), Int32?.none,
-        Int64.random(in: .min ... .max), Int64?.none,
-        UInt.random(in: .min ... .max), UInt?.none,
-        UInt8.random(in: .min ... .max), UInt8?.none,
-        UInt16.random(in: .min ... .max), UInt16?.none,
-        UInt32.random(in: .min ... .max), UInt32?.none,
-        UInt64.random(in: .min ... .max), UInt64?.none,
-        Double.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude), Double?.none,
-        Float.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude), Float?.none,
-        Float16.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude), Float16?.none
-    ]
-    #else
-    /// An array of randomly generated `FNVHashable` values.
     let inputs: [FNVHashable] = [
         "this is a test \u{10424}", String?.none,
         Bool.random(), Bool?.none,
@@ -80,8 +59,6 @@ class HashStabilityTests: XCTestCase {
         Double.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude), Double?.none,
         Float.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude), Float?.none,
     ]
-    #endif
-    
     
     /// Calls `checkStability(of:withHasher:)` for each input in `inputs` and every hasher type.
     ///
@@ -102,4 +79,23 @@ class HashStabilityTests: XCTestCase {
             checkStability(of: input, withHasher: FNV1024a.self)
         }
     }
+    
+#if swift(>=5.4) && !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
+    @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+    func testFloat16() {
+        let input = Float16.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude)
+        checkStability(of: input, withHasher: FNV32a.self)
+        checkStability(of: input, withHasher: FNV64.self)
+        checkStability(of: input, withHasher: FNV64a.self)
+        checkStability(of: input, withHasher: FNV128.self)
+        checkStability(of: input, withHasher: FNV128a.self)
+        checkStability(of: input, withHasher: FNV256.self)
+        checkStability(of: input, withHasher: FNV256a.self)
+        checkStability(of: input, withHasher: FNV512.self)
+        checkStability(of: input, withHasher: FNV512a.self)
+        checkStability(of: input, withHasher: FNV1024.self)
+        checkStability(of: input, withHasher: FNV1024a.self)
+    }
+#endif
+
 }


### PR DESCRIPTION
### Objectives

This pull request changes the availability of the `Float16` extension that declares conformance to `FNVHashable` to avoid build errors on old toolchain versions and Linux on x86_64 architectures.

### Implementation

The new availability statement matches the [Swift Numerics project's code](https://github.com/apple/swift-numerics):
```swift
#if swift(>=5.4) && !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
```

### Tasks

- [x] Update the availability conditional in `FNVHashable.swift`
- [x] Add a `Float16` value to `HashStabilityTests`
- [x] Ensure updated test suite passes on all platforms
