### PR TITLE
Fix Floating Point Zero Hash Values

### DIFF
--- a/Sources/FowlerNollVo/FNVHashable.swift
+++ b/Sources/FowlerNollVo/FNVHashable.swift
@@ -48,13 +48,13 @@ public protocol FNVHashable {
 
 extension Double: FNVHashable {
     public func hash<Hasher>(into hasher: inout Hasher) where Hasher : FNVHasher {
-        withUnsafeBytes(of: self) { hasher.combine($0) }
+        hasher.combine(isZero ? Double.zero.bitPattern : bitPattern)
     }
 }
 
 extension Float: FNVHashable {
     public func hash<Hasher>(into hasher: inout Hasher) where Hasher : FNVHasher {
-        withUnsafeBytes(of: self) { hasher.combine($0) }
+        hasher.combine(isZero ? Float.zero.bitPattern : bitPattern)
     }
 }
 
@@ -68,7 +68,7 @@ extension Float: FNVHashable {
 @available(tvOS 14, *)
 extension Float16: FNVHashable {
     public func hash<Hasher>(into hasher: inout Hasher) where Hasher : FNVHasher {
-        withUnsafeBytes(of: self) { hasher.combine($0) }
+        hasher.combine(isZero ? Float16.zero.bitPattern : bitPattern)
     }
 }
 #endif

--- a/Tests/FowlerNollVoTests/FloatingPointHashingTests.swift
+++ b/Tests/FowlerNollVoTests/FloatingPointHashingTests.swift
@@ -59,6 +59,7 @@ class FloatingPointHashingTests: XCTestCase {
     }
     
 #if swift(>=5.4) && !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
+    @available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
     func testFloat16() {
         let type = Float16.self
         test(type: type, hasher: FNV32.self)

--- a/Tests/FowlerNollVoTests/FloatingPointHashingTests.swift
+++ b/Tests/FowlerNollVoTests/FloatingPointHashingTests.swift
@@ -1,0 +1,78 @@
+//
+//  FloatingPointHashingTests.swift
+//  
+//
+//  Created by Christopher Richez on 2/3/22.
+//
+
+import FowlerNollVo
+import XCTest
+
+/// This test case asserts different representations of zero still return the same hash value.
+class FloatingPointHashingTests: XCTestCase {
+    func test<T, Hasher>(type: T.Type, hasher: Hasher.Type)
+    where T : BinaryFloatingPoint & FNVHashable, Hasher : FNVHasher, Hasher.Digest : Equatable {
+        // Get both representations of zero
+        let plusZero = T(sign: .plus, exponent: 1, significand: 0.0)
+        let minusZero = T(sign: .minus, exponent: 1, significand: 0.0)
+        
+        // Hash both values
+        var plusHasher = Hasher()
+        plusZero.hash(into: &plusHasher)
+        var minusHasher = Hasher()
+        minusZero.hash(into: &minusHasher)
+        
+        // Compare their digests
+        XCTAssertEqual(plusHasher.digest, minusHasher.digest)
+    }
+    
+    func testFloat() {
+        let type = Float.self
+        test(type: type, hasher: FNV32.self)
+        test(type: type, hasher: FNV32a.self)
+        test(type: type, hasher: FNV64.self)
+        test(type: type, hasher: FNV64a.self)
+        test(type: type, hasher: FNV128.self)
+        test(type: type, hasher: FNV128a.self)
+        test(type: type, hasher: FNV256.self)
+        test(type: type, hasher: FNV256a.self)
+        test(type: type, hasher: FNV512.self)
+        test(type: type, hasher: FNV512a.self)
+        test(type: type, hasher: FNV1024.self)
+        test(type: type, hasher: FNV1024a.self)
+    }
+    
+    func testDouble() {
+        let type = Double.self
+        test(type: type, hasher: FNV32.self)
+        test(type: type, hasher: FNV32a.self)
+        test(type: type, hasher: FNV64.self)
+        test(type: type, hasher: FNV64a.self)
+        test(type: type, hasher: FNV128.self)
+        test(type: type, hasher: FNV128a.self)
+        test(type: type, hasher: FNV256.self)
+        test(type: type, hasher: FNV256a.self)
+        test(type: type, hasher: FNV512.self)
+        test(type: type, hasher: FNV512a.self)
+        test(type: type, hasher: FNV1024.self)
+        test(type: type, hasher: FNV1024a.self)
+    }
+    
+#if swift(>=5.4) && !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
+    func testFloat16() {
+        let type = Float16.self
+        test(type: type, hasher: FNV32.self)
+        test(type: type, hasher: FNV32a.self)
+        test(type: type, hasher: FNV64.self)
+        test(type: type, hasher: FNV64a.self)
+        test(type: type, hasher: FNV128.self)
+        test(type: type, hasher: FNV128a.self)
+        test(type: type, hasher: FNV256.self)
+        test(type: type, hasher: FNV256a.self)
+        test(type: type, hasher: FNV512.self)
+        test(type: type, hasher: FNV512a.self)
+        test(type: type, hasher: FNV1024.self)
+        test(type: type, hasher: FNV1024a.self)
+    }
+#endif
+}


### PR DESCRIPTION
### Objectives

This pull request forces both floating point representations of zero to have the same hash value. This aligns the behavior of `FNVHashable` floating points with Swift `Hashable`, and closes #26.

### Tasks

- [x] Write unit tests for each type and hasher
- [x] Update `FNVHashable` implementation for `Float16`
- [x] Update `FNVHashable` implementation for `Float`
- [x] Update `FNVHashable` implementation for `Double`
- [ ] Ensure updated test suite passes on all platforms.
